### PR TITLE
Fix SCT-1659

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,36 +1,11 @@
-FROM kbase/kbase:sdkbase.latest
-MAINTAINER KBase Developer [Michael Sneddon (mwsneddon@lbl.gov)]
+FROM kbase/kbase:sdkbase2.latest
+MAINTAINER KBase Developer
 
-# RUN apt-get update
-RUN pip install --upgrade pip
-
-#RUN apt-get install -y python-coverage
+# Here we install a python coverage tool
 RUN pip install coverage
 
-
-# update security libraries in the base image
-#RUN pip install cffi --upgrade \
-#    && pip install pyopenssl --upgrade \
-#    && pip install ndg-httpsclient --upgrade \
-#    && pip install pyasn1 --upgrade \
-#    && pip install requests --upgrade \
-#    && pip install 'requests[security]' --upgrade
-
-RUN sudo apt-get install python-dev libffi-dev libssl-dev
-RUN pip install cffi --upgrade
-RUN pip install pyopenssl --upgrade
-RUN pip install ndg-httpsclient --upgrade
-RUN pip install pyasn1 --upgrade
-
-RUN pip install requests --upgrade \
-    && pip install 'requests[security]' --upgrade \
-    && pip install ipython \
-    && apt-get install nano
-
-
 # install cutadapt
-RUN pip install cutadapt==1.14
-
+RUN pip install cutadapt==1.18
 
 COPY ./ /kb/module
 RUN mkdir -p /kb/module/work

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,9 @@
+### Verson 1.0.7
+__Changes__
+- fix to build from sdkbase2 image
+- updated cutadapt version to 1.18
+- handle paired end reads properly, e.g., by including both -A and -a options
+
 ### Verson 1.0.6
 __Changes__
 - changed citation for PLOS format

--- a/kbase.yml
+++ b/kbase.yml
@@ -8,7 +8,7 @@ service-language:
     python
 
 module-version:
-    1.0.6
+    1.0.7
 
 owners:
-    [msneddon, dylan, qzhang, mclark58]
+    [msneddon, dylan, qzhang, mclark58, jmc]

--- a/lib/kb_cutadapt/CutadaptUtil.py
+++ b/lib/kb_cutadapt/CutadaptUtil.py
@@ -74,10 +74,16 @@ class CutadaptRunner:
         if self.three_prime:
             cmd.append('-a')
             cmd.append(self.three_prime)
+            if self.interleaved:
+                cmd.append('-A')
+                cmd.append(self.three_prime)
 
         if self.five_prime:
             cmd.append('-g')
             cmd.append(self.five_prime)
+            if self.interleaved:
+                cmd.append('-G')
+                cmd.append(self.five_prime)
 
         if self.err_tolerance:
             cmd.append('--error-rate=' + str(self.err_tolerance))

--- a/test/kb_cutadapt_server_test.py
+++ b/test/kb_cutadapt_server_test.py
@@ -459,7 +459,7 @@ class kb_cutadaptTest(unittest.TestCase):
     ### TEST 1: run Cutadapt against just one single end library
     #
     # Uncomment to skip this test
-    @unittest.skip("skipped test_basic_options_SE_Lib")
+    # @unittest.skip("skipped test_basic_options_SE_Lib")
     def test_basic_options_SE_Lib(self):
 
         print ("\n\nRUNNING: test_basic_options_SE_Lib()")
@@ -499,7 +499,7 @@ class kb_cutadaptTest(unittest.TestCase):
     ### TEST 2: run Cutadapt against just one paired end library
     #
     # Uncomment to skip this test
-    @unittest.skip("skipped test_basic_options_PE_Lib")
+    # @unittest.skip("skipped test_basic_options_PE_Lib")
     def test_basic_options_PE_Lib(self):
 
         print ("\n\nRUNNING: test_basic_options_PE_Lib()")
@@ -539,7 +539,7 @@ class kb_cutadaptTest(unittest.TestCase):
     ### TEST 3: run Cutadapt against single end reads set
     #
     # Uncomment to skip this test
-    @unittest.skip("skipped test_basic_options_SE_ReadsSet")
+    # @unittest.skip("skipped test_basic_options_SE_ReadsSet")
     def test_basic_options_SE_ReadsSet(self):
 
         print ("\n\nRUNNING: test_basic_options_SE_ReadsSet()")
@@ -579,7 +579,7 @@ class kb_cutadaptTest(unittest.TestCase):
     ### TEST 4: run Cutadapt against paired end reads set
     #
     # Uncomment to skip this test
-    @unittest.skip("skipped test_basic_options_PE_ReadsSet")
+    # @unittest.skip("skipped test_basic_options_PE_ReadsSet")
     def test_basic_options_PE_ReadsSet(self):
 
         print ("\n\nRUNNING: test_basic_options_PE_ReadsSet()")
@@ -619,7 +619,7 @@ class kb_cutadaptTest(unittest.TestCase):
     ### TEST 5: run Cutadapt against just one paired end library with 3 prime adapter (anchored)
     #
     # Uncomment to skip this test
-    @unittest.skip("skipped test_basic_options_PE_Lib_threeprime_anchored")
+    # @unittest.skip("skipped test_basic_options_PE_Lib_threeprime_anchored")
     def test_basic_options_PE_Lib_threeprime_anchored(self):
 
         print ("\n\nRUNNING: test_basic_options_PE_Lib_threeprime_anchored()")
@@ -659,7 +659,7 @@ class kb_cutadaptTest(unittest.TestCase):
     ### TEST 6: run Cutadapt against just one paired end library with 3 prime adapter (unanchored)
     #
     # Uncomment to skip this test
-    @unittest.skip("skipped test_basic_options_PE_Lib_threeprime_UNanchored")
+    # @unittest.skip("skipped test_basic_options_PE_Lib_threeprime_UNanchored")
     def test_basic_options_PE_Lib_threeprime_UNanchored(self):
 
         print ("\n\nRUNNING: test_basic_options_PE_Lib_threeprime_UNanchored()")
@@ -699,7 +699,7 @@ class kb_cutadaptTest(unittest.TestCase):
     ### TEST 7: run Cutadapt against just one paired end library with 5 prime unanchored
     #
     # Uncomment to skip this test
-    @unittest.skip("skipped test_basic_options_PE_Lib_fiveprime_UNanchored")
+    # @unittest.skip("skipped test_basic_options_PE_Lib_fiveprime_UNanchored")
     def test_basic_options_PE_Lib_fiveprime_UNanchored(self):
 
         print ("\n\nRUNNING: test_basic_options_PE_Lib_fiveprime_UNanchored()")
@@ -740,7 +740,7 @@ class kb_cutadaptTest(unittest.TestCase):
     ### TEST 8: run Cutadapt against just one paired end library with discard_untrimmed
     #
     # Uncomment to skip this test
-    #@unittest.skip("skipped test_discard_untrimmed_option_PE_Lib")
+    # @unittest.skip("skipped test_discard_untrimmed_option_PE_Lib")
     def test_discard_untrimmed_option_PE_Lib(self):
 
         print ("\n\nRUNNING: test_discard_untrimmed_option_PE_Lib()")

--- a/ui/narrative/methods/remove_adapters/display.yaml
+++ b/ui/narrative/methods/remove_adapters/display.yaml
@@ -1,7 +1,7 @@
 #
 # define display information
 #
-name: Cutadapt - v1.14
+name: Cutadapt - v1.18
 
 tooltip: |
     Removes 3' or 5' adapters from reads using cutadapt

--- a/ui/narrative/methods/remove_adapters/spec.json
+++ b/ui/narrative/methods/remove_adapters/spec.json
@@ -1,7 +1,7 @@
 {
-    "ver": "1.0.5",
+    "ver": "1.0.7",
     "contact": "http://kbase.us/contact-us/",
-    "authors": [ "msneddon", "dylan", "qzhang" ],
+    "authors": [ "msneddon", "dylan", "qzhang", "jmc" ],
     "visible" : true,
     "categories": ["active","reads"],
 


### PR DESCRIPTION
- fix to build from sdkbase2 image
- updated cutadapt version to 1.18
- handle paired end reads properly, e.g., by including both -A and -a options